### PR TITLE
Adds support for non-gazebo simulators

### DIFF
--- a/bwi_launch/launch/includes/simulation.launch.xml
+++ b/bwi_launch/launch/includes/simulation.launch.xml
@@ -1,8 +1,11 @@
 <launch>
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml"/>
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml"/>
+  <arg name="non_gazebo_sim" default="false"/>
 
   <!-- start the simulation environment -->
-  <include file="$(find utexas_gdc)/launch/simulation_multimap.launch" />
+  <group unless="$(arg non_gazebo_sim)">
+      <include file="$(find utexas_gdc)/launch/simulation_multimap.launch" />
+  </group>
 
   <!-- launch the multi map server for the simulated world -->
   <node name="multi_level_map_server" pkg="multi_level_map_server" type="multi_level_map_server">
@@ -12,11 +15,13 @@
   <!-- Set the default level we'd like this robot to start on -->
   <param name="level_mux/default_current_level" value="3rdFloor" />
 
-  <!-- Add simulation helpers for opening and closing doors, and teleporting the robot through elevators. -->
-  <include file="$(find segbot_simulation_apps)/launch/door_handler.launch" />
-  <node name="robot_teleporter" pkg="segbot_simulation_apps" type="robot_teleporter">
-    <param name="robotid" value="segbot" />
-  </node>
+  <!-- Add simulation helpers for opening and closing doors, and teleporting the robot through elevators. --> 
+  <group unless="$(arg non_gazebo_sim)">
+      <include file="$(find segbot_simulation_apps)/launch/door_handler.launch" />
+      <node name="robot_teleporter" pkg="segbot_simulation_apps" type="robot_teleporter">
+        <param name="robotid" value="segbot" />
+      </node>
+  </group>
 
   <!-- also launch the level multiplexer and the level selector -->
   <node name="level_mux" pkg="multi_level_map_utils" type="level_mux">

--- a/bwi_launch/launch/includes/simulation.launch.xml
+++ b/bwi_launch/launch/includes/simulation.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml"/>
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap/combined.yaml"/>
   <arg name="non_gazebo_sim" default="false"/>
 
   <!-- start the simulation environment -->

--- a/bwi_launch/launch/simulation_v2.f1tenth.launch
+++ b/bwi_launch/launch/simulation_v2.f1tenth.launch
@@ -1,0 +1,10 @@
+<launch>
+
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml" />
+
+  <include file="$(find bwi_launch)/launch/simulation_v2.launch">
+    <arg name="multimap_file" value="$(arg multimap_file)"/>
+    <arg name="non_gazebo_sim" value="true"/>
+  </include>
+
+</launch>

--- a/bwi_launch/launch/simulation_v2.launch
+++ b/bwi_launch/launch/simulation_v2.launch
@@ -1,15 +1,16 @@
 <launch>
 
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml" />
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml" />
   <arg name="x" default="15.0" />
   <arg name="y" default="110.0" />
   <arg name="yaw" default="0" />
   <arg name="use_arm" default="false" />
   <arg name="use_perception" default="false" />
-
+  <arg name="non_gazebo_sim" default="false" />
 
   <include file="$(find bwi_launch)/launch/includes/simulation.launch.xml" >
-    <arg name="multimap_file" value="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml" />
+    <arg name="multimap_file" value="$(arg multimap_file)"/>
+    <arg name="non_gazebo_sim" value="$(arg non_gazebo_sim)"/>
   </include>
 
   <!-- launch robot description and robot internal tf tree, along with any common nodes between h/w and software-->
@@ -29,6 +30,7 @@
     <arg name="y" value="$(arg y)" />
     <arg name="yaw" value="$(arg yaw)" />
     <arg name="robotid" value="segbot" />
+    <arg name="non_gazebo_sim" value="$(arg non_gazebo_sim)"/>
     <arg name="map_frame" value="level_mux_map" />
     <arg name="map_service" value="level_mux/static_map" />
     <arg name="map_topic" value="level_mux/map" />

--- a/bwi_launch/launch/simulation_v2.launch
+++ b/bwi_launch/launch/simulation_v2.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml" />
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml" />
   <arg name="x" default="15.0" />
   <arg name="y" default="110.0" />
   <arg name="yaw" default="0" />


### PR DESCRIPTION
This PR introduces a method to handle bringing up the BWI navigation stack in simulation without relying on Gazebo. 

The existing method of bringing up the simulator retains expected behavior, i.e. by default running

     $ roslaunch bwi_launch simulation_v2.launch

will still bring up Gazebo sim and the BWI stack.

This is dependent on the following PRs: utexas-bwi/segbot#114, utexas-bwi/bwi_common#114

To run this code with the f1tenth simulator (which is the main target for this PR) the feature branches of each of those repositories should be checked out.