### PR TITLE
Realistic gazebo simulator world

### DIFF
--- a/bwi_launch/launch/includes/simulation.launch.xml
+++ b/bwi_launch/launch/includes/simulation.launch.xml
@@ -1,8 +1,11 @@
 <launch>
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml"/>
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml"/>
+  <arg name="non_gazebo_sim" default="false"/>
 
   <!-- start the simulation environment -->
-  <include file="$(find utexas_gdc)/launch/simulation_multimap.launch" />
+  <group unless="$(arg non_gazebo_sim)">
+      <include file="$(find utexas_gdc)/launch/simulation_multimap.launch" />
+  </group>
 
   <!-- launch the multi map server for the simulated world -->
   <node name="multi_level_map_server" pkg="multi_level_map_server" type="multi_level_map_server">
@@ -12,11 +15,13 @@
   <!-- Set the default level we'd like this robot to start on -->
   <param name="level_mux/default_current_level" value="3rdFloor" />
 
-  <!-- Add simulation helpers for opening and closing doors, and teleporting the robot through elevators. -->
-  <include file="$(find segbot_simulation_apps)/launch/door_handler.launch" />
-  <node name="robot_teleporter" pkg="segbot_simulation_apps" type="robot_teleporter">
-    <param name="robotid" value="segbot" />
-  </node>
+  <!-- Add simulation helpers for opening and closing doors, and teleporting the robot through elevators. --> 
+  <group unless="$(arg non_gazebo_sim)">
+      <include file="$(find segbot_simulation_apps)/launch/door_handler.launch" />
+      <node name="robot_teleporter" pkg="segbot_simulation_apps" type="robot_teleporter">
+        <param name="robotid" value="segbot" />
+      </node>
+  </group>
 
   <!-- also launch the level multiplexer and the level selector -->
   <node name="level_mux" pkg="multi_level_map_utils" type="level_mux">

--- a/bwi_launch/launch/includes/simulation.launch.xml
+++ b/bwi_launch/launch/includes/simulation.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml"/>
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap/combined.yaml"/>
   <arg name="non_gazebo_sim" default="false"/>
 
   <!-- start the simulation environment -->

--- a/bwi_launch/launch/includes/simulation.launch.xml
+++ b/bwi_launch/launch/includes/simulation.launch.xml
@@ -1,10 +1,16 @@
 <launch>
   <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap/combined.yaml"/>
-  <arg name="non_gazebo_sim" default="false"/>
+  <arg name="realistic_gazebo_sim" default="false"/>
+  
 
   <!-- start the simulation environment -->
-  <group unless="$(arg non_gazebo_sim)">
+  <group unless="$(arg realistic_gazebo_sim)">
       <include file="$(find utexas_gdc)/launch/simulation_multimap.launch" />
+  </group>
+  <group if="$(arg realistic_gazebo_sim)">
+      <include file="$(find utexas_gdc)/launch/simulation_3ne.launch">
+        <arg name="realistic" value="true"/>
+      </include>
   </group>
 
   <!-- launch the multi map server for the simulated world -->
@@ -16,12 +22,10 @@
   <param name="level_mux/default_current_level" value="3rdFloor" />
 
   <!-- Add simulation helpers for opening and closing doors, and teleporting the robot through elevators. --> 
-  <group unless="$(arg non_gazebo_sim)">
-      <include file="$(find segbot_simulation_apps)/launch/door_handler.launch" />
-      <node name="robot_teleporter" pkg="segbot_simulation_apps" type="robot_teleporter">
-        <param name="robotid" value="segbot" />
-      </node>
-  </group>
+  <include file="$(find segbot_simulation_apps)/launch/door_handler.launch" />
+  <node name="robot_teleporter" pkg="segbot_simulation_apps" type="robot_teleporter">
+    <param name="robotid" value="segbot" />
+  </node>
 
   <!-- also launch the level multiplexer and the level selector -->
   <node name="level_mux" pkg="multi_level_map_utils" type="level_mux">

--- a/bwi_launch/launch/simulation_v2.f1tenth.launch
+++ b/bwi_launch/launch/simulation_v2.f1tenth.launch
@@ -1,0 +1,10 @@
+<launch>
+
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml" />
+
+  <include file="$(find bwi_launch)/launch/simulation_v2.launch">
+    <arg name="multimap_file" value="$(arg multimap_file)"/>
+    <arg name="non_gazebo_sim" value="true"/>
+  </include>
+
+</launch>

--- a/bwi_launch/launch/simulation_v2.launch
+++ b/bwi_launch/launch/simulation_v2.launch
@@ -6,11 +6,11 @@
   <arg name="yaw" default="0" />
   <arg name="use_arm" default="false" />
   <arg name="use_perception" default="false" />
-  <arg name="non_gazebo_sim" default="false" />
+  <arg name="realistic_gazebo_sim" default="false" />
 
   <include file="$(find bwi_launch)/launch/includes/simulation.launch.xml" >
     <arg name="multimap_file" value="$(arg multimap_file)"/>
-    <arg name="non_gazebo_sim" value="$(arg non_gazebo_sim)"/>
+    <arg name="realistic_gazebo_sim" value="$(arg realistic_gazebo_sim)"/>
   </include>
 
   <!-- launch robot description and robot internal tf tree, along with any common nodes between h/w and software-->
@@ -30,7 +30,6 @@
     <arg name="y" value="$(arg y)" />
     <arg name="yaw" value="$(arg yaw)" />
     <arg name="robotid" value="segbot" />
-    <arg name="non_gazebo_sim" value="$(arg non_gazebo_sim)"/>
     <arg name="map_frame" value="level_mux_map" />
     <arg name="map_service" value="level_mux/static_map" />
     <arg name="map_topic" value="level_mux/map" />

--- a/bwi_launch/launch/simulation_v2.launch
+++ b/bwi_launch/launch/simulation_v2.launch
@@ -1,15 +1,16 @@
 <launch>
 
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml" />
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml" />
   <arg name="x" default="15.0" />
   <arg name="y" default="110.0" />
   <arg name="yaw" default="0" />
   <arg name="use_arm" default="false" />
   <arg name="use_perception" default="false" />
-
+  <arg name="non_gazebo_sim" default="false" />
 
   <include file="$(find bwi_launch)/launch/includes/simulation.launch.xml" >
-    <arg name="multimap_file" value="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml" />
+    <arg name="multimap_file" value="$(arg multimap_file)"/>
+    <arg name="non_gazebo_sim" value="$(arg non_gazebo_sim)"/>
   </include>
 
   <!-- launch robot description and robot internal tf tree, along with any common nodes between h/w and software-->
@@ -29,6 +30,7 @@
     <arg name="y" value="$(arg y)" />
     <arg name="yaw" value="$(arg yaw)" />
     <arg name="robotid" value="segbot" />
+    <arg name="non_gazebo_sim" value="$(arg non_gazebo_sim)"/>
     <arg name="map_frame" value="level_mux_map" />
     <arg name="map_service" value="level_mux/static_map" />
     <arg name="map_topic" value="level_mux/map" />

--- a/bwi_launch/launch/simulation_v2.launch
+++ b/bwi_launch/launch/simulation_v2.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/f1tenth_sim/combined.yaml" />
+  <arg name="multimap_file" default="$(find utexas_gdc)/maps/simulation/multimap2/combined.yaml" />
   <arg name="x" default="15.0" />
   <arg name="y" default="110.0" />
   <arg name="yaw" default="0" />

--- a/bwi_launch/launch/simulation_v2.realistic_gazebo.launch
+++ b/bwi_launch/launch/simulation_v2.realistic_gazebo.launch
@@ -1,0 +1,10 @@
+<launch>
+
+  <include file="$(find bwi_launch)/launch/simulation_v2.launch">
+    <arg name="multimap_file" value="$(find utexas_gdc)/maps/real/multimap/3_only_multimap.yaml" />
+    <arg name="x" value="-9.0" />
+    <arg name="y" value="-12.0" />
+    <arg name="realistic_gazebo_sim" value="true"/>
+  </include>
+
+</launch>


### PR DESCRIPTION
This in combination with utexas-bwi/bwi_common#115 adds the ability to launch a Gazebo world that is more realistic (in terms of structural dimensions) than the one currently used by default.

This PR adds launch files and arguments that make running this realistic world simple, however it preserves backwards compatibility by making the current Gazebo sim world the default.

To run this new world, launch with 

    $ roslaunch bwi_launch simulation_v2.realistic_gazebo.launch

 with `bwi_common` on the `feature/realistic_gazebo_sim` branch as well.