### PR TITLE
Add Melodic upgrade path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ It may already be.  If not, issue the appropriate one of these two
 shell commands:
 
 ```
-$ export ROS_DISTRO=indigo
+$ export ROS_DISTRO=kinetic
 ```
 or
 ```
-$ export ROS_DISTRO=kinetic
+$ export ROS_DISTRO=melodic
 ```
 
 Next, clone the source repositories:
@@ -63,12 +63,12 @@ $ rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 
 Then, build everything:
 ```
-$ catkin build
+$ catkin build --mem-limit 50%
 $ source devel/setup.bash
 ```
 
 Note that the **catkin build** command from the **python-catkin-tools**
-package is *required* for building on ROS Kinetic.  On ROS Indigo, you
+package is *required* for building on ROS Kinetic and Melodic. On ROS Indigo, you
 can still use **catkin_make** instead, although the newer build tool
 is recommended.
 

--- a/bwi_launch/launch/includes/simulation_ns.launch.xml
+++ b/bwi_launch/launch/includes/simulation_ns.launch.xml
@@ -44,8 +44,10 @@
       <arg name="y" value="$(arg y)" />
       <arg name="yaw" value="$(arg yaw)" />
       <arg name="robotid" value="$(arg ns)" />
-      <arg name="tf_prefix" value="$(arg ns)" />
-      <arg name="map_frame" value="level_mux_map" />
+      <arg name="tf_prefix" value="$(arg ns)"/>
+      <arg name="odom_frame_id" value="$(arg ns)/odom" />
+      <arg name="base_frame_id" value="$(arg ns)/base_footprint" />
+      <arg name="map_frame" value="$(arg ns)/level_mux_map" />
       <arg name="map_service" value="level_mux/static_map" />
       <arg name="map_topic" value="level_mux/map" />
       <arg name="navigation_map_topic" value="bwi_logical_navigator/map" />

--- a/bwi_launch/launch/simulation_v2.launch
+++ b/bwi_launch/launch/simulation_v2.launch
@@ -14,6 +14,7 @@
 
   <!-- launch robot description and robot internal tf tree, along with any common nodes between h/w and software-->
   <include file="$(find segbot_bringup)/launch/includes/auxiliary.segbot_v2.launch.xml">
+    <arg name="simulation" value="true"/>
     <arg name="use_full_gazebo_model" value="false" />
     <arg name="tf_prefix" value="" />
     <arg name="use_nav_kinect" value="true" />

--- a/rosinstall/melodic.rosinstall
+++ b/rosinstall/melodic.rosinstall
@@ -11,6 +11,14 @@
     uri: https://github.com/utexas-bwi/bwi_common.git
     version: devel
 - git:
+    local-name: camera1394
+    uri: https://github.com/ros-drivers/camera1394
+    version: master
+- git:
+    local-name: frontier_exploration
+    uri: https://github.com/paulbovbel/frontier_exploration.git
+    version: melodic-devel
+- git:
     local-name: kinova-ros
     uri: https://github.com/utexas-bwi/kinova-ros.git
     version: melodic-devel
@@ -24,8 +32,8 @@
     version: melodic-devel
 - git:
     local-name: segway_rmp
-    uri: https://github.com/segwayrmp/segway_rmp.git
-    version: master
+    uri: https://github.com/utexas-bwi/segway_rmp.git
+    version: melodic-devel
 - git:
     local-name: segway_v3
     uri: https://github.com/utexas-bwi/segway_v3.git

--- a/rosinstall/melodic.rosinstall
+++ b/rosinstall/melodic.rosinstall
@@ -1,0 +1,32 @@
+- git:
+    local-name: agile_grasp
+    uri: https://github.com/utexas-bwi/agile_grasp.git
+    version: melodic-devel
+- git:
+    local-name: bwi
+    uri: https://github.com/utexas-bwi/bwi.git
+    version: master
+- git:
+    local-name: bwi_common
+    uri: https://github.com/utexas-bwi/bwi_common.git
+    version: devel
+- git:
+    local-name: kinova-ros
+    uri: https://github.com/utexas-bwi/kinova-ros.git
+    version: melodic-devel
+- git:
+    local-name: libsegwayrmp
+    uri: https://github.com/utexas-bwi/libsegwayrmp.git
+    version: cpp11
+- git:
+    local-name: segbot
+    uri: https://github.com/utexas-bwi/segbot.git
+    version: melodic-devel
+- git:
+    local-name: segway_rmp
+    uri: https://github.com/segwayrmp/segway_rmp.git
+    version: master
+- git:
+    local-name: segway_v3
+    uri: https://github.com/utexas-bwi/segway_v3.git
+    version: melodic-devel


### PR DESCRIPTION
This adds an upgrade path to Melodic by introducing a `.rosinstall` script with the appropriate development branches specified, and updating the README for Melodic install instructions.

This is a non-breaking merge. As mentioned above, most the branches specified are development branches. One day soon, some of those repositories will migrate their melodic development branches into their master branch. When this happens, the `melodic.rosinstall` file this PR introduces should be updated.
